### PR TITLE
Increase the number of validators added per day to 1350

### DIFF
--- a/ethereum-2.0-depositing.md
+++ b/ethereum-2.0-depositing.md
@@ -52,7 +52,7 @@ Once the deposit is in the deposit contract, the state of the validator will swi
 
 ![](.gitbook/assets/image%20%28108%29.png)
 
-The deposit is accessible now for the beacon-chain. Depending on the amount of total deposits, the validators have to wait in a queue. Five validators per [Epoch](https://kb.beaconcha.in/glossary#epoch) \(**1125 validators per day\)** can get activated.
+The deposit is accessible now for the beacon-chain. Depending on the amount of total deposits, the validators have to wait in a queue. Six validators per [Epoch](https://kb.beaconcha.in/glossary#epoch) \(**1350 validators per day\)** can get activated.
 
 ## 4. Staking - Status: Active
 

--- a/glossary.md
+++ b/glossary.md
@@ -129,7 +129,13 @@ Waiting for activation on ETH2
 
 Before validators enter the validator queue, they need to be voted in by other active validators. This occurs every 4 hours.
 
-* Until 327680 active validators in the network, **4 validators can be activated per epoch**.  For every **65536** \(=4 \* 16384\) active validator, the validator **activation rate** goes up by one. 5 validators per epoch requires 327680 active validators. 
+* Until 327680 active validators in the network, 4 validators can be activated per epoch.  For every **65536** \(=4 \* 16384\) active validator, the validator **activation rate** goes up by one.
+* 5 validators per epoch requires 327680 active validators which translates to 1125 validators per day.
+* 6 validators per epoch requires 393216 active validators which translates to 1350 validators per day.
+* 7 validators per epoch requires 458752 active validators which translates to 1575 validators per day.
+* 8 validators per epoch requires 524288 active validators which translates to 1800 validators per day.
+* 9 validators per epoch requires 589824 active validators which translates to 2025 validators per day.
+* 10 validators per epoch requires 655360 active validators which translates to 2200 validators per day.
 * Amount of activations scales with the amount of active validators and the limit is the active validator set divided by 64.000
 
 #### **3. Active Validator** 


### PR DESCRIPTION
We have reached the magic number of 393216 (6 x 65536) validators, so now instead of adding 5 validators per epoch, we now add 6.

1440 minutes per day -> 225 epoch -> 1350 validator in/out the queue.